### PR TITLE
fixed language code from jp to ja

### DIFF
--- a/lib/src/i18n/all.dart
+++ b/lib/src/i18n/all.dart
@@ -8,7 +8,7 @@ import 'fr.dart';
 import 'he.dart';
 import 'id.dart';
 import 'it.dart';
-import 'jp.dart';
+import 'ja.dart';
 import 'pl.dart';
 import 'pt_br.dart';
 import 'tr.dart';
@@ -28,7 +28,7 @@ const localeMap = <String, FormValidatorLocale>{
   'zh-cn': LocaleZhCN(),
   'en': LocaleEn(),
   'he': LocaleHe(),
-  'jp': LocaleJp(),
+  'ja': LocaleJa(),
 };
 
 final supportedLocales = localeMap.keys.toList();

--- a/lib/src/i18n/all.dart
+++ b/lib/src/i18n/all.dart
@@ -9,6 +9,7 @@ import 'he.dart';
 import 'id.dart';
 import 'it.dart';
 import 'ja.dart';
+import 'jp.dart';
 import 'pl.dart';
 import 'pt_br.dart';
 import 'tr.dart';
@@ -29,6 +30,7 @@ const localeMap = <String, FormValidatorLocale>{
   'en': LocaleEn(),
   'he': LocaleHe(),
   'ja': LocaleJa(),
+  'jp': LocaleJp(),
 };
 
 final supportedLocales = localeMap.keys.toList();

--- a/lib/src/i18n/ja.dart
+++ b/lib/src/i18n/ja.dart
@@ -1,10 +1,10 @@
 import '../locale.dart';
 
-class LocaleJp implements FormValidatorLocale {
-  const LocaleJp();
+class LocaleJa implements FormValidatorLocale {
+  const LocaleJa();
 
   @override
-  String name() => 'jp';
+  String name() => 'ja';
 
   @override
   String minLength(String v, int n) => 'フィールドは$n文字以上である必要があります';

--- a/lib/src/i18n/jp.dart
+++ b/lib/src/i18n/jp.dart
@@ -1,0 +1,32 @@
+import '../locale.dart';
+
+class LocaleJp implements FormValidatorLocale {
+  const LocaleJp();
+
+  @override
+  String name() => 'jp';
+
+  @override
+  String minLength(String v, int n) => 'フィールドは$n文字以上である必要があります';
+
+  @override
+  String maxLength(String v, int n) => 'フィールドの長さは最大$n文字である必要があります';
+
+  @override
+  String email(String v) => '有効なメールアドレスではありません';
+
+  @override
+  String phoneNumber(String v) => '有効な電話番号ではありません';
+
+  @override
+  String required() => 'は必須項目です';
+
+  @override
+  String ip(String v) => '有効なIPではありません';
+
+  @override
+  String ipv6(String v) => '有効なIPv6xではありません';
+
+  @override
+  String url(String v) => '有効なxxxではありません';
+}


### PR DESCRIPTION
Hi @themisir I've changed the Japanese code from "jp" to "ja" as commented in this topic 
https://github.com/themisir/form-validator/issues/34

Just to recap

**Why**: Flutter's list of supported locales include "ja" instead of "jp", this small bug is causing an app "crash" when loading a validated form field.
The list of Flutter's default language codes https://api.flutter.dev/flutter/flutter_localizations/GlobalMaterialLocalizations-class.html

**How**: Changed every reference to "jp" in "ja"

See also Stack Overflow issue 
https://stackoverflow.com/questions/62540699/flutter-internationalization-for-japanese-failed