### PR TITLE
Update Turkish (tr) language translations & Email validation regex

### DIFF
--- a/lib/src/i18n/tr.dart
+++ b/lib/src/i18n/tr.dart
@@ -7,19 +7,19 @@ class LocaleTr implements FormValidatorLocale {
   String name() => 'tr';
 
   @override
-  String minLength(String v, int n) => 'Bu alan en az $n harf olmalı';
+  String minLength(String v, int n) => 'Bu alan en az $n karakter içermelidir';
 
   @override
-  String maxLength(String v, int n) => 'Bu alan en fazla $n harf olmalı';
+  String maxLength(String v, int n) => 'Bu alan $n karakterden uzun olamaz';
 
   @override
-  String email(String v) => 'Email adresi geçerli değil';
+  String email(String v) => 'Lütfen doğru bir E-Posta adresi girin';
 
   @override
-  String phoneNumber(String v) => 'Telefon numarası geçerli değil';
+  String phoneNumber(String v) => 'Lütfen doğru bir telefon numarası girin';
 
   @override
-  String required() => 'Bu alan zorunludur';
+  String required() => 'Lütfen doldurun';
 
   @override
   String ip(String v) => 'IP adresi geçerli değil';

--- a/lib/src/validator_builder.dart
+++ b/lib/src/validator_builder.dart
@@ -27,7 +27,7 @@ class ValidationBuilder {
   }
 
   static final RegExp _emailRegExp = RegExp(
-      r"^[a-zA-Z0-9.a-zA-Z0-9.!#$%&'*+-/=?^_`{|}~]+@[a-zA-Z0-9\-\_]+(\.[a-zA-Z]+)*$");
+      r"^[a-zA-Z0-9.a-zA-Z0-9.!#$%&'*+-\/=?^_`{|}~]{1,30}+@[a-zA-Z0-9\-\_]{1,30}+(\.[a-zA-Z]{1,20}+)*$");
   static final RegExp _nonDigitsExp = RegExp(r'[^\d]');
   static final RegExp _anyLetter = RegExp(r'[A-Za-z]');
   static final RegExp _phoneRegExp = RegExp(r'^\d{7,15}$');

--- a/lib/src/validator_builder.dart
+++ b/lib/src/validator_builder.dart
@@ -27,7 +27,7 @@ class ValidationBuilder {
   }
 
   static final RegExp _emailRegExp = RegExp(
-      r"^[a-zA-Z0-9.a-zA-Z0-9.!#$%&'*+-\/=?^_`{|}~]{1,30}+@[a-zA-Z0-9\-\_]{1,30}+(\.[a-zA-Z]{1,20}+)*$");
+      r"^[a-zA-Z0-9.a-zA-Z0-9.!#$%&'*+-/=?^_`{|}~]+@[a-zA-Z0-9\-\_]+(\.[a-zA-Z]+)*$");
   static final RegExp _nonDigitsExp = RegExp(r'[^\d]');
   static final RegExp _anyLetter = RegExp(r'[A-Za-z]');
   static final RegExp _phoneRegExp = RegExp(r'^\d{7,15}$');


### PR DESCRIPTION
Changed email validation error message since it contains “E-mail” in Turkish language. Also changed other language translations as I saw them fit. Would like to hear your opinions.