### PR TITLE
Added support for all data type validation

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -66,7 +66,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.0.0"
+    version: "2.1.1"
   matcher:
     dependency: transitive
     description:

--- a/lib/src/validator_builder.dart
+++ b/lib/src/validator_builder.dart
@@ -2,12 +2,12 @@ import 'i18n/all.dart';
 import 'locale.dart';
 import 'validator_options.dart';
 
-typedef StringValidationCallback = String? Function(String? value);
+typedef StringValidationCallback<T> = String? Function(T? value);
 
 // C# Action<T>
 typedef Action<T> = Function(T builder);
 
-class ValidationBuilder {
+class ValidationBuilder<T> {
   ValidationBuilder({
     this.optional = false,
     this.requiredMessage,
@@ -54,10 +54,10 @@ class ValidationBuilder {
   }
 
   /// Tests [value] against defined [validations]
-  String? test(String? value) {
+  String? test(T? value) {
     for (var validate in validations) {
       // Return null if field is optional and value is null
-      if (optional && (value == null || value.isEmpty)) {
+      if (optional && (value == null || value.toString().isEmpty)) {
         return null;
       }
 
@@ -71,7 +71,7 @@ class ValidationBuilder {
   }
 
   /// Returns a validator function for FormInput
-  StringValidationCallback build() => test;
+  StringValidationCallback<T> build() => test;
 
   /// Throws error only if [left] and [right] validators throw error same time.
   /// If [reverse] is true left builder's error will be displayed otherwise
@@ -109,8 +109,8 @@ class ValidationBuilder {
   }
 
   /// Value must not be null
-  ValidationBuilder required([String? message]) =>
-      add((v) => v == null || v.isEmpty ? message ?? _locale.required() : null);
+  ValidationBuilder required([String? message]) => add((v) =>
+      v == null || v.toString().isEmpty ? message ?? _locale.required() : null);
 
   /// Value length must be greater than or equal to [minLength]
   ValidationBuilder minLength(int minLength, [String? message]) =>

--- a/lib/src/validator_builder.dart
+++ b/lib/src/validator_builder.dart
@@ -7,7 +7,7 @@ typedef StringValidationCallback<T> = String? Function(T? value);
 // C# Action<T>
 typedef Action<T> = Function(T builder);
 
-class ValidationBuilder<T> {
+class ValidationBuilder {
   ValidationBuilder({
     this.optional = false,
     this.requiredMessage,
@@ -54,10 +54,10 @@ class ValidationBuilder<T> {
   }
 
   /// Tests [value] against defined [validations]
-  String? test(T? value) {
+  String? test(var value) {
     for (var validate in validations) {
       // Return null if field is optional and value is null
-      if (optional && (value == null || value.toString().isEmpty)) {
+      if (optional && (value == null || value.isEmpty)) {
         return null;
       }
 
@@ -71,7 +71,7 @@ class ValidationBuilder<T> {
   }
 
   /// Returns a validator function for FormInput
-  StringValidationCallback<T> build() => test;
+  StringValidationCallback build() => test;
 
   /// Throws error only if [left] and [right] validators throw error same time.
   /// If [reverse] is true left builder's error will be displayed otherwise


### PR DESCRIPTION
### Fixes #47 
The dropdown widget uses value parameters to differentiate between different items. This value parameter can be of any data type. For example, we preferred an integer value for every dropdown menu item.

[Here](https://github.com/themisir/form-validator/issues/47#issuecomment-1320944885), it was suggested to use DropdownButtonFormField\<String>. I think users of this package must be free to use any data type, not just String.

This update will enable the option to use it like ValidationBuilder\<int>().build(); 